### PR TITLE
feat: add suggested-metrics CLI command

### DIFF
--- a/src/linter/rules/suggestedMetricSuggestionRule.ts
+++ b/src/linter/rules/suggestedMetricSuggestionRule.ts
@@ -1,131 +1,15 @@
 import * as jsonc from 'jsonc-parser';
 import { ILinterRule, LintResult, Signal, LintSeverity, LinterRuleConfig } from './rule';
-
-/**
- * Mapping of signal patterns to suggested metrics
- */
-interface MetricPattern {
-  idPattern?: RegExp;
-  namePattern?: RegExp;
-  excludeNamePattern?: RegExp;
-  suggestedMetric: string;
-  description: string;
-}
+import { METRIC_PATTERNS } from '../../utils/suggestedMetricPatterns';
 
 /**
  * Rule that suggests adding suggestedMetric properties based on signal ID and name patterns
+ * 
+ * Uses the canonical METRIC_PATTERNS from suggestedMetricPatterns.ts as the single source of truth.
+ * This eliminates duplication and ensures the VSCode plugin and CLI always use identical patterns.
  */
 export class SuggestedMetricSuggestionRule implements ILinterRule {
-  private readonly metricPatterns: MetricPattern[] = [
-    // Tire pressure patterns
-    {
-      idPattern: /TP_FL|TIRE.*PRESSURE.*FL|FL.*TIRE.*PRESSURE/i,
-      namePattern: /front\s+left\s+tire\s+pressure/i,
-      suggestedMetric: 'frontLeftTirePressure',
-      description: 'Front left tire pressure'
-    },
-    {
-      idPattern: /TP_FR|TIRE.*PRESSURE.*FR|FR.*TIRE.*PRESSURE/i,
-      namePattern: /front\s+right\s+tire\s+pressure/i,
-      suggestedMetric: 'frontRightTirePressure',
-      description: 'Front right tire pressure'
-    },
-    {
-      idPattern: /TP_RL|TIRE.*PRESSURE.*RL|RL.*TIRE.*PRESSURE/i,
-      namePattern: /rear\s+left\s+tire\s+pressure/i,
-      suggestedMetric: 'rearLeftTirePressure',
-      description: 'Rear left tire pressure'
-    },
-    {
-      idPattern: /TP_RR|TIRE.*PRESSURE.*RR|RR.*TIRE.*PRESSURE/i,
-      namePattern: /rear\s+right\s+tire\s+pressure/i,
-      suggestedMetric: 'rearRightTirePressure',
-      description: 'Rear right tire pressure'
-    },
-
-    // Tire temperature patterns
-    {
-      idPattern: /TT_FL|TIRE.*TEMP.*FL|FL.*TIRE.*TEMP/i,
-      namePattern: /front\s+left\s+tire\s+temp/i,
-      suggestedMetric: 'frontLeftTireTemperature',
-      description: 'Front left tire temperature'
-    },
-    {
-      idPattern: /TT_FR|TIRE.*TEMP.*FR|FR.*TIRE.*TEMP/i,
-      namePattern: /front\s+right\s+tire\s+temp/i,
-      suggestedMetric: 'frontRightTireTemperature',
-      description: 'Front right tire temperature'
-    },
-    {
-      idPattern: /TT_RL|TIRE.*TEMP.*RL|RL.*TIRE.*TEMP/i,
-      namePattern: /rear\s+left\s+tire\s+temp/i,
-      suggestedMetric: 'rearLeftTireTemperature',
-      description: 'Rear left tire temperature'
-    },
-    {
-      idPattern: /TT_RR|TIRE.*TEMP.*RR|RR.*TIRE.*TEMP/i,
-      namePattern: /rear\s+right\s+tire\s+temp/i,
-      suggestedMetric: 'rearRightTireTemperature',
-      description: 'Rear right tire temperature'
-    },
-
-    // Speed patterns
-    {
-      idPattern: /_?VSS(_|$)/i,
-      namePattern: /vehicle\s+speed|^speed$/i,
-      suggestedMetric: 'speed',
-      description: 'Vehicle speed'
-    },
-
-    // Odometer patterns
-    {
-      idPattern: /ODO(_|$)/i,
-      namePattern: /odometer/i,
-      suggestedMetric: 'odometer',
-      description: 'Odometer'
-    },
-
-    // State of charge patterns - exclude minimum/maximum cell SOC
-    {
-      idPattern: /_?SOC(_|$)|STATE.*CHARGE/i,
-      namePattern: /state\s+of\s+charge|battery.*charge.*%|soc/i,
-      excludeNamePattern: /minimum|maximum|min\s+|max\s+|cell/i,
-      suggestedMetric: 'stateOfCharge',
-      description: 'Battery state of charge'
-    },
-
-    // State of health patterns
-    {
-      idPattern: /_?SOH(_|$)|STATE.*HEALTH/i,
-      namePattern: /state\s+of\s+health|battery.*health/i,
-      suggestedMetric: 'stateOfHealth',
-      description: 'Battery state of health'
-    },
-
-    // Traction battery voltage (HV battery)
-    {
-      idPattern: /HV.*BAT.*VOLT|TRACTION.*BAT.*VOLT|HIGH.*VOLT.*BAT.*VOLT/i,
-      namePattern: /high\s+voltage\s+battery.*voltage|traction\s+battery.*voltage|hv\s+battery.*voltage/i,
-      suggestedMetric: 'tractionBatteryVoltage',
-      description: 'Traction battery voltage'
-    },
-
-    // Starter battery voltage (12V / Aux battery)
-    {
-      idPattern: /12V_V|AUX.*BAT.*VOLT|AUXIL.*BAT.*VOLT/i,
-      namePattern: /auxiliary\s+battery\s+voltage|12v.*voltage|starter\s+battery/i,
-      suggestedMetric: 'starterBatteryVoltage',
-      description: 'Starter battery voltage'
-    },
-
-    // Charging status
-    {
-      idPattern: /HV_CHARGING|IS_CHARGING|CHARGING_STATUS/i,
-      namePattern: /charging\?|is\s+charging|charging\s+status/i,
-      suggestedMetric: 'isCharging',
-      description: 'Charging status'
-    },
-  ];
+  private readonly metricPatterns = METRIC_PATTERNS;
 
   /**
    * Gets the rule configuration
@@ -156,7 +40,7 @@ export class SuggestedMetricSuggestionRule implements ILinterRule {
       return null;
     }
 
-    // Check each pattern
+    // Check each pattern from the canonical source
     for (const pattern of this.metricPatterns) {
       const idMatches = pattern.idPattern ? pattern.idPattern.test(signal.id) : false;
       const nameMatches = pattern.namePattern ? pattern.namePattern.test(signal.name) : false;


### PR DESCRIPTION
Exposes the official SuggestedMetricSuggestionRule to the CLI, allowing users to identify which signals in a signalset should have suggestedMetric fields added.

## Usage

```bash
obdb suggested-metrics <workspace-path> [signal-id]
```

## Example

```bash
$ obdb suggested-metrics "/path/to/Toyota-RAV4-Hybrid" --signal RAV4HYBRID_HVBAT_V
[\n  {\n    "signalId": "RAV4HYBRID_HVBAT_V",\n    "signalName": "HV battery voltage",\n    "suggestedMetric": "tractionBatteryVoltage",\n    "description": "Traction battery voltage"\n  }\n]\n```

## Implementation

- Uses the official `SuggestedMetricSuggestionRule.validateSignal()` method directly
- No pattern duplication - all suggestion logic comes from the existing linting rule
- Output is JSON format for easy integration with tools and scripts
- Integrates seamlessly with existing CLI commands (lint, optimize, command-support)

This enables programmatic access to the same metric suggestions that the VSCode plugin provides, making it easier to batch-process signalsets and identify missing suggestedMetric mappings.